### PR TITLE
apply Autofill Slug to the view

### DIFF
--- a/src/Scissorhands.NET/Views/Post/Write.cshtml
+++ b/src/Scissorhands.NET/Views/Post/Write.cshtml
@@ -18,9 +18,14 @@
                 <label asp-for="Slug"></label>
                 <div class="input-group">
                     <div class="input-group-addon">@Model.SlugPrefix/</div>
-                    <input class="form-control" asp-for="Slug"/>
+                    <input trigger-field="Title" lock-checkbox="SlugEdit"  class="form-control slug-input" asp-for="Slug"/>
                     <div class="input-group-addon">.html</div>
                 </div>
+            </div>
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" id="SlugEdit"> Edit Slug
+                </label>
             </div>
             <div class="form-group">
                 <label asp-for="Author"></label>
@@ -64,5 +69,7 @@
                 }
             });
         });
+        
+        SlugAutofill.globalInit();
     </script>
 }

--- a/src/Scissorhands.NET/wwwroot/js/slug.js
+++ b/src/Scissorhands.NET/wwwroot/js/slug.js
@@ -88,6 +88,9 @@
 
     function clickCheckbox() {
       ele.prop('readonly', !$(this).is(':checked'));
+      if (!$(this).is(':checked')) {
+        trigger.trigger('change');
+      }
     }
   };
 

--- a/src/Scissorhands.NET/wwwroot/js/slug.js
+++ b/src/Scissorhands.NET/wwwroot/js/slug.js
@@ -80,7 +80,9 @@
     lock.on('click', clickCheckbox);
 
     function updateSlug() {
-      ele.val(SlugAutofill.parse($(this).val()));
+      if (ele.prop('readonly')) {
+        ele.val(SlugAutofill.parse($(this).val()));
+      }
     }
 
     function clickCheckbox() {

--- a/src/Scissorhands.NET/wwwroot/js/slug.js
+++ b/src/Scissorhands.NET/wwwroot/js/slug.js
@@ -76,6 +76,7 @@
 
     // initialize the events
     trigger.on('change', updateSlug);
+    trigger.on('keyup', updateSlug);
     lock.on('change', clickCheckbox);
     lock.on('click', clickCheckbox);
 

--- a/src/Scissorhands.NET/wwwroot/js/tests/slug_test.js
+++ b/src/Scissorhands.NET/wwwroot/js/tests/slug_test.js
@@ -106,6 +106,17 @@ describe("There is a tick box right next to the slug field", function() {
         expect(result).to.equal(defaultText);
       });
     });
+    describe("Subject field", function() {
+      it("should not update the slug field", function() {
+        var deniableSubject = "It shouldn't be here.";
+        var deniableResult = SlugAutofill.parse(deniableSubject);
+
+        $slugTrigger.val(deniableSubject).trigger('change');
+
+        var result = $slugInput.val();
+        expect(result).to.not.equal(deniableResult);
+      });
+    });
   });
 
   describe("When the tick box is checked and then unchecked", function() {

--- a/src/Scissorhands.NET/wwwroot/js/tests/slug_test.js
+++ b/src/Scissorhands.NET/wwwroot/js/tests/slug_test.js
@@ -107,4 +107,31 @@ describe("There is a tick box right next to the slug field", function() {
       });
     });
   });
+
+  describe("When the tick box is checked and then unchecked", function() {
+    var defaultText, alternativeText;
+
+    beforeEach(function() {
+      defaultText = "Answer to the Ultimate Question of Life, the Universe, and Everything";
+      alternativeText = "The-snow-glows-white-on-the-mountain-tonight";
+    });
+
+    describe("Slug field", function() {
+      it("should get new slug using the current subject", function() {
+
+        // fill defaultText and get the result
+        $slugTrigger.val(defaultText).trigger('change');
+        var originalResult = $slugInput.val();
+
+        // action tick and update the slug, then untick
+        $slugCheckbox.trigger('click');
+        $slugInput.val(alternativeText);
+        $slugCheckbox.trigger('click');
+
+        var result = $slugInput.val();
+        expect(result).to.equal(originalResult);
+      });
+    })
+
+  });
 });


### PR DESCRIPTION
Firstly, Thanks for @justinyoo, your scratch of JS testing environment. It's super awesome! :+1: :+1: 

I updated the view as the https://github.com/getscissorhands/Scissorhands.NET/issues/49#issuecomment-177231730. During the apply, I found some usability issue so I updated the autofill slug slightly. You can see the change in the story.

- When a user checks the edit slug tickbox, the subject field shouldn't update the slug field.
- When a user checks the tickbox and then unchecks that, the slug text should update it using the current subject.

Please review the PR.