### PR TITLE
Updating \r\n to Environment.NewLine for cross-platform

### DIFF
--- a/test/Scissorhands.Services.Tests/PublishServiceTest.cs
+++ b/test/Scissorhands.Services.Tests/PublishServiceTest.cs
@@ -128,7 +128,7 @@ namespace Scissorhands.Services.Tests
             markdown.Should().ContainEquivalentOf($"* Slug: {slug}");
             markdown.Should().ContainEquivalentOf($"* Author: {author}");
             markdown.Should().ContainEquivalentOf($"* Tags: {string.Join(", ", tags.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries))}");
-            markdown.Should().EndWithEquivalent($"{body}\r\n");
+            markdown.Should().EndWithEquivalent($"{body}"+Environment.NewLine);
         }
 
         /// <summary>

--- a/test/Scissorhands.Services.Tests/PublishServiceTest.cs
+++ b/test/Scissorhands.Services.Tests/PublishServiceTest.cs
@@ -128,7 +128,7 @@ namespace Scissorhands.Services.Tests
             markdown.Should().ContainEquivalentOf($"* Slug: {slug}");
             markdown.Should().ContainEquivalentOf($"* Author: {author}");
             markdown.Should().ContainEquivalentOf($"* Tags: {string.Join(", ", tags.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries))}");
-            markdown.Should().EndWithEquivalent($"{body}"+Environment.NewLine);
+            markdown.Should().EndWithEquivalent($"{body}{Environment.NewLine}");
         }
 
         /// <summary>


### PR DESCRIPTION
Used `Environment.NewLine` instead of `\r\n`. `Environment.NewLine` is automatically converted to `\r\n` or `\n` based on your environment. [Reference here](https://dotnet.github.io/api/System.Environment.html#System_Environment_NewLine)

issue #66