### PR TITLE
Add cascading parameters for theme views

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ A Blazor-based static site generator
     ```csharp
     using ScissorHands.Web;
 
-    var app = await new ScissorHandsApplication<MainLayout, IndexView, PostView, PageView>(args)
-                        .VerifyCommandArguments()
-                        .BuildAsync();
+    var app = new ScissorHandsApplicationBuilder(args)
+                  .AddLayouts<MainLayout, IndexView, PostView, PageView, NotFoundView>()
+                  .Build();
     await app.RunAsync();
     ```
 

--- a/src/ScissorHands.Theme/IndexViewBase.cs
+++ b/src/ScissorHands.Theme/IndexViewBase.cs
@@ -13,24 +13,24 @@ public abstract class IndexViewBase : ComponentBase
     /// <summary>
     /// Gets or sets the list of <see cref="ContentDocument"/> instances.
     /// </summary>
-    [Parameter]
-    public IEnumerable<ContentDocument> Documents { get; set; } = [];
+    [CascadingParameter]
+    public IEnumerable<ContentDocument>? Documents { get; set; }
 
     /// <summary>
     /// Gets or sets the list of <see cref="PluginManifest"/> instances.
     /// </summary>
-    [Parameter]
+    [CascadingParameter]
     public IEnumerable<PluginManifest>? Plugins { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="ThemeManifest"/> instance.
     /// </summary>
-    [Parameter]
+    [CascadingParameter]
     public ThemeManifest? Theme { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="SiteManifest"/> instance.
     /// </summary>
-    [Parameter]
+    [CascadingParameter]
     public SiteManifest? Site { get; set; }
 }

--- a/src/ScissorHands.Theme/NotFoundViewBase.cs
+++ b/src/ScissorHands.Theme/NotFoundViewBase.cs
@@ -14,24 +14,24 @@ public abstract class NotFoundViewBase : ComponentBase
     /// Gets or sets the <see cref="ContentDocument"/> instance.
     /// If a page document with the slug <c>404.html</c> exists, it will be provided here.
     /// </summary>
-    [Parameter]
-    public ContentDocument Document { get; set; } = new();
+    [CascadingParameter]
+    public ContentDocument? Document { get; set; }
 
     /// <summary>
     /// Gets or sets the list of <see cref="PluginManifest"/> instances.
     /// </summary>
-    [Parameter]
+    [CascadingParameter]
     public IEnumerable<PluginManifest>? Plugins { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="ThemeManifest"/> instance.
     /// </summary>
-    [Parameter]
+    [CascadingParameter]
     public ThemeManifest? Theme { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="SiteManifest"/> instance.
     /// </summary>
-    [Parameter]
+    [CascadingParameter]
     public SiteManifest? Site { get; set; }
 }

--- a/src/ScissorHands.Theme/PageViewBase.cs
+++ b/src/ScissorHands.Theme/PageViewBase.cs
@@ -13,24 +13,24 @@ public abstract class PageViewBase : ComponentBase
     /// <summary>
     /// Gets or sets the <see cref="ContentDocument"/> instance.
     /// </summary>
-    [Parameter]
-    public ContentDocument Document { get; set; } = new();
+    [CascadingParameter]
+    public ContentDocument? Document { get; set; }
 
     /// <summary>
     /// Gets or sets the list of <see cref="PluginManifest"/> instances.
     /// </summary>
-    [Parameter]
+    [CascadingParameter]
     public IEnumerable<PluginManifest>? Plugins { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="ThemeManifest"/> instance.
     /// </summary>
-    [Parameter]
+    [CascadingParameter]
     public ThemeManifest? Theme { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="SiteManifest"/> instance.
     /// </summary>
-    [Parameter]
+    [CascadingParameter]
     public SiteManifest? Site { get; set; }
 }

--- a/src/ScissorHands.Theme/PostViewBase.cs
+++ b/src/ScissorHands.Theme/PostViewBase.cs
@@ -13,24 +13,24 @@ public abstract class PostViewBase : ComponentBase
     /// <summary>
     /// Gets or sets the <see cref="ContentDocument"/> instance.
     /// </summary>
-    [Parameter]
-    public ContentDocument Document { get; set; } = new();
+    [CascadingParameter]
+    public ContentDocument? Document { get; set; }
 
     /// <summary>
     /// Gets or sets the list of <see cref="PluginManifest"/> instances.
     /// </summary>
-    [Parameter]
+    [CascadingParameter]
     public IEnumerable<PluginManifest>? Plugins { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="ThemeManifest"/> instance.
     /// </summary>
-    [Parameter]
+    [CascadingParameter]
     public ThemeManifest? Theme { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="SiteManifest"/> instance.
     /// </summary>
-    [Parameter]
+    [CascadingParameter]
     public SiteManifest? Site { get; set; }
 }

--- a/src/ScissorHands.Web/Generators/StaticSiteGenerator.cs
+++ b/src/ScissorHands.Web/Generators/StaticSiteGenerator.cs
@@ -69,10 +69,10 @@ public sealed class StaticSiteGenerator(
         var notFoundDocument = documents.SingleOrDefault(d => d.Kind == ContentKind.Page && string.Equals(d.Metadata.Slug, PAGE_NOT_FOUND_SLUG, StringComparison.OrdinalIgnoreCase));
         await RenderNotFoundAsync<TNotFoundView>(notFoundDocument, plugins, theme, destination, layoutType, cancellationToken);
 
-        var buildTasks = documents.Where(d => IsNotFoundPage(d) == false)
-                                  .Select(d => RenderDocumentAsync<TPostView, TPageView>(d, plugins, theme, destination, layoutType, cancellationToken))
-                                  .ToList();
-        await Task.WhenAll(buildTasks);
+        foreach (var document in documents.Where(d => IsNotFoundPage(d) == false))
+        {
+            await RenderDocumentAsync<TPostView, TPageView>(document, plugins, theme, destination, layoutType, cancellationToken);
+        }
 
         CopyContentAssets(destination);
         await _themeService.CopyAssetsAsync(_options.Theme, destination);

--- a/src/ScissorHands.Web/Generators/StaticSiteGenerator.cs
+++ b/src/ScissorHands.Web/Generators/StaticSiteGenerator.cs
@@ -69,40 +69,10 @@ public sealed class StaticSiteGenerator(
         var notFoundDocument = documents.SingleOrDefault(d => d.Kind == ContentKind.Page && string.Equals(d.Metadata.Slug, PAGE_NOT_FOUND_SLUG, StringComparison.OrdinalIgnoreCase));
         await RenderNotFoundAsync<TNotFoundView>(notFoundDocument, plugins, theme, destination, layoutType, cancellationToken);
 
-        foreach (var document in documents)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            if (document.Kind == ContentKind.Page && string.Equals(document.Metadata.Slug, PAGE_NOT_FOUND_SLUG, StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            var preProcessed = await _pluginRunner.RunPreMarkdownAsync(document, cancellationToken);
-            var html = await _markdownService.ToHtmlAsync(preProcessed.Markdown, cancellationToken: cancellationToken);
-            preProcessed.Html = html;
-            var postMarkdown = await _pluginRunner.RunPostMarkdownAsync(preProcessed, cancellationToken);
-
-            var parameters = new Dictionary<string, object?>
-            {
-                ["Document"] = postMarkdown,
-                ["Plugins"] = plugins,
-                ["Theme"] = theme,
-                ["Site"] = _options
-            };
-
-            var rendered = postMarkdown.Kind switch
-            {
-                ContentKind.Page => await _renderer.RenderAsync<TPageView>(layoutType, parameters, cancellationToken),
-                _ => await _renderer.RenderAsync<TPostView>(layoutType, parameters, cancellationToken)
-            };
-
-            var finalHtml = await _pluginRunner.RunPostHtmlAsync(rendered, postMarkdown, cancellationToken);
-            var outputPath = ResolveOutputPath(destination, postMarkdown.Metadata.Slug);
-            _fileSystem.Directory.CreateDirectory(_fileSystem.Path.GetDirectoryName(outputPath)!);
-            await _fileSystem.File.WriteAllTextAsync(outputPath, finalHtml, Encoding.UTF8, cancellationToken);
-            _logger.LogInformation("Wrote {OutputPath}", outputPath);
-        }
+        var buildTasks = documents.Where(d => IsNotFoundPage(d) == false)
+                                  .Select(d => RenderDocumentAsync<TPostView, TPageView>(d, plugins, theme, destination, layoutType, cancellationToken))
+                                  .ToList();
+        await Task.WhenAll(buildTasks);
 
         CopyContentAssets(destination);
         await _themeService.CopyAssetsAsync(_options.Theme, destination);
@@ -188,6 +158,44 @@ public sealed class StaticSiteGenerator(
         _fileSystem.Directory.CreateDirectory(_fileSystem.Path.GetDirectoryName(outputPath)!);
         await _fileSystem.File.WriteAllTextAsync(outputPath, finalHtml, Encoding.UTF8, cancellationToken);
         _logger.LogInformation("Wrote {OutputPath}", outputPath);
+    }
+
+    private async Task RenderDocumentAsync<TPostView, TPageView>(ContentDocument document, IEnumerable<PluginManifest> plugins, ThemeManifest theme, string destination, Type layoutType, CancellationToken cancellationToken)
+        where TPostView : ScissorHands.Theme.PostViewBase
+        where TPageView : ScissorHands.Theme.PageViewBase
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var preProcessed = await _pluginRunner.RunPreMarkdownAsync(document, cancellationToken);
+        var html = await _markdownService.ToHtmlAsync(preProcessed.Markdown, cancellationToken: cancellationToken);
+        preProcessed.Html = html;
+        var postMarkdown = await _pluginRunner.RunPostMarkdownAsync(preProcessed, cancellationToken);
+
+        var parameters = new Dictionary<string, object?>
+        {
+            ["Document"] = postMarkdown,
+            ["Plugins"] = plugins,
+            ["Theme"] = theme,
+            ["Site"] = _options
+        };
+
+        var rendered = postMarkdown.Kind switch
+        {
+            ContentKind.Page => await _renderer.RenderAsync<TPageView>(layoutType, parameters, cancellationToken),
+            _ => await _renderer.RenderAsync<TPostView>(layoutType, parameters, cancellationToken)
+        };
+
+        var finalHtml = await _pluginRunner.RunPostHtmlAsync(rendered, postMarkdown, cancellationToken);
+        var outputPath = ResolveOutputPath(destination, postMarkdown.Metadata.Slug);
+        _fileSystem.Directory.CreateDirectory(_fileSystem.Path.GetDirectoryName(outputPath)!);
+        await _fileSystem.File.WriteAllTextAsync(outputPath, finalHtml, Encoding.UTF8, cancellationToken);
+        _logger.LogInformation("Wrote {OutputPath}", outputPath);
+    }
+
+    private static bool IsNotFoundPage(ContentDocument document)
+    {
+        return document.Kind == ContentKind.Page &&
+               string.Equals(document.Metadata.Slug, PAGE_NOT_FOUND_SLUG, StringComparison.OrdinalIgnoreCase) == true;
     }
 
     private static string ResolveOutputPath(string root, string slug)

--- a/src/ScissorHands.Web/Generators/StaticSiteGenerator.cs
+++ b/src/ScissorHands.Web/Generators/StaticSiteGenerator.cs
@@ -30,8 +30,8 @@ public sealed class StaticSiteGenerator(
         IPluginRunner pluginRunner,
         IThemeService themeService,
         IComponentRenderer renderer,
-    IAppPaths paths,
-    IFileSystem fileSystem,
+        IAppPaths paths,
+        IFileSystem fileSystem,
         SiteManifest options,
         ILogger<StaticSiteGenerator> logger) : IStaticSiteGenerator
 {

--- a/src/ScissorHands.Web/Renderers/ComponentRenderer.cs
+++ b/src/ScissorHands.Web/Renderers/ComponentRenderer.cs
@@ -31,8 +31,23 @@ public sealed class ComponentRenderer(IServiceScopeFactory scopeFactory, ILogger
             {
                 builder.OpenComponent<TComponent>(0);
                 var seq = 1;
+
+                var cascadingKeys = new HashSet<string>(StringComparer.Ordinal)
+                {
+                    "Documents",
+                    "Document",
+                    "Plugins",
+                    "Theme",
+                    "Site"
+                };
+
                 foreach (var kvp in parameters)
                 {
+                    if (cascadingKeys.Contains(kvp.Key))
+                    {
+                        continue;
+                    }
+
                     builder.AddAttribute(seq++, kvp.Key, kvp.Value);
                 }
                 builder.CloseComponent();

--- a/src/ScissorHands.Web/Renderers/ComponentRenderer.cs
+++ b/src/ScissorHands.Web/Renderers/ComponentRenderer.cs
@@ -1,7 +1,11 @@
+using System.Reflection;
+
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+
+using ScissorHands.Theme;
 
 namespace ScissorHands.Web.Renderers;
 
@@ -14,6 +18,39 @@ public sealed class ComponentRenderer(IServiceScopeFactory scopeFactory, ILogger
 {
     private readonly IServiceScopeFactory _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
     private readonly ILoggerFactory _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+
+    // Lazy initialization of cascading parameter names discovered via reflection
+    private static readonly Lazy<HashSet<string>> _cascadingParameterNames = new(() =>
+    {
+        var parameterNames = new HashSet<string>(StringComparer.Ordinal);
+
+        // Discover all types in the ScissorHands.Theme assembly that have cascading parameters
+        var themeAssembly = typeof(PageViewBase).Assembly;
+        
+        try
+        {
+            var allTypes = themeAssembly.GetExportedTypes();
+
+            foreach (var type in allTypes)
+            {
+                // Find all properties with CascadingParameter attribute
+                var cascadingProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                    .Where(p => p.GetCustomAttribute<CascadingParameterAttribute>() is not null);
+
+                foreach (var property in cascadingProperties)
+                {
+                    parameterNames.Add(property.Name);
+                }
+            }
+        }
+        catch (ReflectionTypeLoadException)
+        {
+            // If type loading fails, fall back to empty set
+            // This should not happen in normal operation, but provides safety
+        }
+
+        return parameterNames;
+    });
 
     /// <inheritdoc />
     public async Task<string> RenderAsync<TComponent>(Type layoutType, IDictionary<string, object?> parameters, CancellationToken cancellationToken = default)
@@ -32,18 +69,9 @@ public sealed class ComponentRenderer(IServiceScopeFactory scopeFactory, ILogger
                 builder.OpenComponent<TComponent>(0);
                 var seq = 1;
 
-                var cascadingKeys = new HashSet<string>(StringComparer.Ordinal)
-                {
-                    "Documents",
-                    "Document",
-                    "Plugins",
-                    "Theme",
-                    "Site"
-                };
-
                 foreach (var kvp in parameters)
                 {
-                    if (cascadingKeys.Contains(kvp.Key))
+                    if (_cascadingParameterNames.Value.Contains(kvp.Key))
                     {
                         continue;
                     }

--- a/src/ScissorHands.Web/ScissorHandsApplication.cs
+++ b/src/ScissorHands.Web/ScissorHandsApplication.cs
@@ -7,9 +7,8 @@ using Microsoft.Extensions.Logging;
 
 using ScissorHands.Core.Manifests;
 using ScissorHands.Core.Options;
-using ScissorHands.Web.Application;
 using ScissorHands.Web.Abstractions;
-using ScissorHands.Web.Extensions;
+using ScissorHands.Web.Application;
 using ScissorHands.Web.Generators;
 
 namespace ScissorHands.Web;
@@ -20,18 +19,6 @@ namespace ScissorHands.Web;
 public interface IScissorHandsApplication
 {
     /// <summary>
-    /// Verifies the command arguments.
-    /// </summary>
-    /// <returns>Returns the <see cref="IScissorHandsApplication"/> instance.</returns>
-    IScissorHandsApplication VerifyCommandArguments();
-
-    /// <summary>
-    /// Builds the application.
-    /// </summary>
-    /// <returns>Returns the <see cref="IScissorHandsApplication"/> instance.</returns>
-    Task<IScissorHandsApplication> BuildAsync();
-
-    /// <summary>
     /// Runs the application.
     /// </summary>
     Task RunAsync();
@@ -40,29 +27,34 @@ public interface IScissorHandsApplication
 /// <summary>
 /// This represents the ScissorHands application entity.
 /// </summary>
-/// <typeparam name="TMainLayout">Type of main layout component.</typeparam>
-/// <typeparam name="TIndexView">Type of index view component.</typeparam>
-/// <typeparam name="TPostView">Type of post view component.</typeparam>
-/// <typeparam name="TPageView">Type of page view component.</typeparam>
-/// <typeparam name="TNotFoundView">Type of not found (404) view component.</typeparam>
-public class ScissorHandsApplication<TMainLayout, TIndexView, TPostView, TPageView, TNotFoundView>(params IEnumerable<string> args) : IScissorHandsApplication
-    where TMainLayout : ScissorHands.Theme.MainLayoutBase
-    where TIndexView : ScissorHands.Theme.IndexViewBase
-    where TPostView : ScissorHands.Theme.PostViewBase
-    where TPageView : ScissorHands.Theme.PageViewBase
-    where TNotFoundView : ScissorHands.Theme.NotFoundViewBase
+public sealed class ScissorHandsApplication : IScissorHandsApplication
 {
     private const string APP_LOGGER_NAME = "App";
 
-    private readonly IEnumerable<string> _args = [.. args];
+    private readonly string[] _args;
+    private readonly Type _mainLayout;
+    private readonly Type _indexView;
+    private readonly Type _postView;
+    private readonly Type _pageView;
+    private readonly Type _notFoundView;
     private CommandMode _mode;
-    private WebApplication? _app;
+    private readonly WebApplication _app;
     private ILogger? _logger;
     private SiteManifest? _site;
     private IStaticSiteGenerator? _generator;
 
-    /// <inheritdoc />
-    public IScissorHandsApplication VerifyCommandArguments()
+    internal ScissorHandsApplication(WebApplication app, IEnumerable<string> args, Type mainLayout, Type indexView, Type postView, Type pageView, Type notFoundView)
+    {
+        _app = app ?? throw new ArgumentNullException(nameof(app));
+        _args = args?.ToArray() ?? throw new ArgumentNullException(nameof(args));
+        _mainLayout = mainLayout ?? throw new ArgumentNullException(nameof(mainLayout));
+        _indexView = indexView ?? throw new ArgumentNullException(nameof(indexView));
+        _postView = postView ?? throw new ArgumentNullException(nameof(postView));
+        _pageView = pageView ?? throw new ArgumentNullException(nameof(pageView));
+        _notFoundView = notFoundView ?? throw new ArgumentNullException(nameof(notFoundView));
+    }
+
+    private void VerifyCommandArguments()
     {
         DisplayBanner();
 
@@ -77,7 +69,7 @@ public class ScissorHandsApplication<TMainLayout, TIndexView, TPostView, TPageVi
         {
             Console.ForegroundColor = ConsoleColor.Red;
             Console.WriteLine();
-            Console.WriteLine("ERROR: No parameter provided.");
+            Console.WriteLine("ERROR: No parameter or invalid parameter provided.");
             Console.ResetColor();
             DisplayHelp();
 
@@ -85,45 +77,28 @@ public class ScissorHandsApplication<TMainLayout, TIndexView, TPostView, TPageVi
         }
 
         _mode = validation.Mode;
-
-        return this;
-    }
-
-    /// <inheritdoc />
-    public async Task<IScissorHandsApplication> BuildAsync()
-    {
-        var builder = WebApplication.CreateBuilder([.. _args]);
-
-        var config = builder.Configuration;
-        builder.Services.AddConfigurations(config)
-                        .AddServices(config)
-                        .AddRazorComponents();
-
-        _app = builder.Build();
-
-        return this;
     }
 
     /// <inheritdoc />
     public async Task RunAsync()
     {
-        if (_mode is not CommandMode.Preview)
-        {
-            return;
-        }
+        VerifyCommandArguments();
 
-        _logger = _app!.Services.GetRequiredService<ILoggerFactory>().CreateLogger(APP_LOGGER_NAME);
-        _site = _app!.Services.GetRequiredService<SiteManifest>();
-        _generator = _app!.Services.GetRequiredService<IStaticSiteGenerator>();
+        _logger = _app.Services.GetRequiredService<ILoggerFactory>().CreateLogger(APP_LOGGER_NAME);
+        _site = _app.Services.GetRequiredService<SiteManifest>();
+        _generator = _app.Services.GetRequiredService<IStaticSiteGenerator>();
 
-        var result = _mode switch
+        _ = _mode switch
         {
             CommandMode.Preview => await RunPreviewServerAsync(),
             CommandMode.Build => await RunBuildAsync(),
             _ => LogInvalidMode()
         };
 
-        await _app!.RunAsync();
+        if (_mode == CommandMode.Preview)
+        {
+            await _app.RunAsync();
+        }
     }
 
     private static void DisplayHelp()
@@ -185,7 +160,7 @@ public class ScissorHandsApplication<TMainLayout, TIndexView, TPostView, TPageVi
             Directory.Delete(previewPath, recursive: true);
         }
 
-        await _generator!.BuildAsync<TMainLayout, TIndexView, TPostView, TPageView, TNotFoundView>(previewPath, preview: true, _app!.Lifetime.ApplicationStopping);
+        await BuildSiteAsync(previewPath, preview: true, _app.Lifetime.ApplicationStopping);
 
         var fileProvider = new PhysicalFileProvider(previewPath);
         _app.UseDefaultFiles(new DefaultFilesOptions { FileProvider = fileProvider });
@@ -211,7 +186,7 @@ public class ScissorHandsApplication<TMainLayout, TIndexView, TPostView, TPageVi
             async () =>
             {
                 _logger!.LogInformation("Change detected; rebuilding preview...");
-                await _generator!.BuildAsync<TMainLayout, TIndexView, TPostView, TPageView, TNotFoundView>(previewPath, preview: true, CancellationToken.None);
+                await BuildSiteAsync(previewPath, preview: true, CancellationToken.None);
                 _logger!.LogInformation("Preview rebuilt. Refresh your browser to see the changes.");
             });
 
@@ -228,10 +203,25 @@ public class ScissorHandsApplication<TMainLayout, TIndexView, TPostView, TPageVi
             Directory.Delete(outputPath, recursive: true);
         }
 
-        await _generator!.BuildAsync<TMainLayout, TIndexView, TPostView, TPageView, TNotFoundView>(outputPath, preview: false, CancellationToken.None);
+        await BuildSiteAsync(outputPath, preview: false, CancellationToken.None);
         _logger!.LogInformation("Build complete. Output at {OutputPath}", outputPath);
 
         return this;
+    }
+
+    private Task BuildSiteAsync(string destination, bool preview, CancellationToken cancellationToken)
+    {
+        var buildMethod = _generator!.GetType()
+                                     .GetMethods()
+                                     .Single(m => string.Equals(m.Name, nameof(IStaticSiteGenerator.BuildAsync), StringComparison.Ordinal) &&
+                                                  m.IsGenericMethodDefinition &&
+                                                  m.GetGenericArguments().Length == 5 &&
+                                                  m.GetParameters().Length == 3);
+
+        var closedMethod = buildMethod.MakeGenericMethod(_mainLayout, _indexView, _postView, _pageView, _notFoundView);
+        var task = (Task?)closedMethod.Invoke(_generator, [ destination, preview, cancellationToken ]);
+
+        return task ?? Task.CompletedTask;
     }
 
     private IScissorHandsApplication LogInvalidMode()

--- a/src/ScissorHands.Web/ScissorHandsApplication.cs
+++ b/src/ScissorHands.Web/ScissorHandsApplication.cs
@@ -1,3 +1,6 @@
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -30,6 +33,8 @@ public interface IScissorHandsApplication
 public sealed class ScissorHandsApplication : IScissorHandsApplication
 {
     private const string APP_LOGGER_NAME = "App";
+    private const int EXPECTED_GENERIC_PARAMETER_COUNT = 5;
+    private const int EXPECTED_METHOD_PARAMETER_COUNT = 3;
 
     private readonly string[] _args;
     private readonly Type _mainLayout;
@@ -42,6 +47,8 @@ public sealed class ScissorHandsApplication : IScissorHandsApplication
     private ILogger? _logger;
     private SiteManifest? _site;
     private IStaticSiteGenerator? _generator;
+    private MethodInfo? _cachedBuildMethod;
+    private readonly object _cacheLock = new object();
 
     internal ScissorHandsApplication(WebApplication app, IEnumerable<string> args, Type mainLayout, Type indexView, Type postView, Type pageView, Type notFoundView)
     {
@@ -211,17 +218,83 @@ public sealed class ScissorHandsApplication : IScissorHandsApplication
 
     private Task BuildSiteAsync(string destination, bool preview, CancellationToken cancellationToken)
     {
-        var buildMethod = _generator!.GetType()
-                                     .GetMethods()
-                                     .Single(m => string.Equals(m.Name, nameof(IStaticSiteGenerator.BuildAsync), StringComparison.Ordinal) &&
-                                                  m.IsGenericMethodDefinition &&
-                                                  m.GetGenericArguments().Length == 5 &&
-                                                  m.GetParameters().Length == 3);
+        try
+        {
+            // Use cached method info if available, otherwise find and cache it
+            if (_cachedBuildMethod == null)
+            {
+                lock (_cacheLock)
+                {
+                    if (_cachedBuildMethod == null)
+                    {
+                        _cachedBuildMethod = GetBuildAsyncMethod();
+                    }
+                }
+            }
 
-        var closedMethod = buildMethod.MakeGenericMethod(_mainLayout, _indexView, _postView, _pageView, _notFoundView);
-        var task = (Task?)closedMethod.Invoke(_generator, [ destination, preview, cancellationToken ]);
+            var closedMethod = _cachedBuildMethod.MakeGenericMethod(_mainLayout, _indexView, _postView, _pageView, _notFoundView);
+            var parameters = new object[] { destination, preview, cancellationToken };
+            var task = (Task?)closedMethod.Invoke(_generator, parameters);
 
-        return task ?? Task.CompletedTask;
+            return task ?? Task.CompletedTask;
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger?.LogError(ex, "Failed to invoke BuildAsync method. The method signature may have changed or multiple overloads exist.");
+            throw new InvalidOperationException("Failed to invoke the BuildAsync method on the static site generator. Please ensure the IStaticSiteGenerator interface has not changed.", ex);
+        }
+        catch (TargetInvocationException ex)
+        {
+            _logger?.LogError(ex.InnerException ?? ex, "BuildAsync method threw an exception during execution.");
+            
+            // Re-throw the inner exception while preserving the stack trace
+            if (ex.InnerException != null)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            }
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            _logger?.LogError(ex, "Failed to create generic method with the provided type arguments.");
+            throw new InvalidOperationException("Failed to create the generic BuildAsync method. The provided view types may not satisfy the required constraints.", ex);
+        }
+    }
+
+    private MethodInfo GetBuildAsyncMethod()
+    {
+        if (_generator == null)
+        {
+            throw new InvalidOperationException("Static site generator has not been initialized.");
+        }
+
+        var generatorType = _generator.GetType();
+        var methods = generatorType.GetMethods()
+            .Where(m => string.Equals(m.Name, nameof(IStaticSiteGenerator.BuildAsync), StringComparison.Ordinal) &&
+                       m.IsGenericMethodDefinition)
+            .ToList();
+
+        if (methods.Count == 0)
+        {
+            throw new InvalidOperationException($"No BuildAsync method found on type {generatorType.Name}. Ensure the generator implements IStaticSiteGenerator.");
+        }
+
+        // Filter to the expected signature: 5 generic parameters, 3 method parameters
+        var matchingMethods = methods.Where(m => m.GetGenericArguments().Length == EXPECTED_GENERIC_PARAMETER_COUNT &&
+                                                  m.GetParameters().Length == EXPECTED_METHOD_PARAMETER_COUNT)
+            .ToList();
+
+        if (matchingMethods.Count == 0)
+        {
+            throw new InvalidOperationException($"No BuildAsync method with the expected signature ({EXPECTED_GENERIC_PARAMETER_COUNT} generic parameters, {EXPECTED_METHOD_PARAMETER_COUNT} method parameters) found on type {generatorType.Name}.");
+        }
+
+        if (matchingMethods.Count > 1)
+        {
+            throw new InvalidOperationException($"Multiple BuildAsync methods with the expected signature found on type {generatorType.Name}. Cannot determine which method to invoke.");
+        }
+
+        return matchingMethods[0];
     }
 
     private IScissorHandsApplication LogInvalidMode()

--- a/src/ScissorHands.Web/ScissorHandsApplicationBuilder.cs
+++ b/src/ScissorHands.Web/ScissorHandsApplicationBuilder.cs
@@ -1,0 +1,124 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+using ScissorHands.Theme;
+using ScissorHands.Web.Extensions;
+
+namespace ScissorHands.Web;
+
+/// <summary>
+/// This provides the interface for ScissorHands application builder.
+/// </summary>
+public interface IScissorHandsApplicationBuilder
+{
+    /// <summary>
+    /// Add layouts to the application.
+    /// </summary>
+    /// <typeparam name="TMainLayout">Type of the main layout.</typeparam>
+    /// <typeparam name="TIndexView">Type of the index view.</typeparam>
+    /// <typeparam name="TPostView">Type of the post view.</typeparam>
+    /// <typeparam name="TPageView">Type of the page view.</typeparam>
+    /// <typeparam name="TNotFoundView">Type of the not found view.</typeparam>
+    /// <returns>Returns <see cref="IScissorHandsApplicationBuilder"/> instance.</returns>
+    IScissorHandsApplicationBuilder AddLayouts<TMainLayout, TIndexView, TPostView, TPageView, TNotFoundView>()
+        where TMainLayout : MainLayoutBase
+        where TIndexView : IndexViewBase
+        where TPostView : PostViewBase
+        where TPageView : PageViewBase
+        where TNotFoundView : NotFoundViewBase;
+
+    /// <summary>
+    /// Add layouts to the application.
+    /// </summary>
+    /// <param name="mainLayout">Type of the main layout.</param>
+    /// <param name="indexView">Type of the index view.</param>
+    /// <param name="postView">Type of the post view.</param>
+    /// <param name="pageView">Type of the page view.</param>
+    /// <param name="notFoundView">Type of the not found view.</param>
+    /// <returns>Returns <see cref="IScissorHandsApplicationBuilder"/> instance.</returns>    
+    IScissorHandsApplicationBuilder AddLayouts(Type mainLayout, Type indexView, Type postView, Type pageView, Type notFoundView);
+
+    /// <summary>
+    /// Builds the application.
+    /// </summary>
+    /// <returns>Returns <see cref="IScissorHandsApplication"/> instance.</returns>
+    IScissorHandsApplication Build();
+}
+
+/// <summary>
+/// This represents the builder entity for <see cref="ScissorHandsApplication"/>.
+/// </summary>
+public sealed class ScissorHandsApplicationBuilder(IEnumerable<string>? args = null) : IScissorHandsApplicationBuilder
+{
+    private readonly string[] _args = (string[])(args ?? []);
+
+    private Type? _mainLayout;
+    private Type? _indexView;
+    private Type? _postView;
+    private Type? _pageView;
+    private Type? _notFoundView;
+
+    /// <inheritdoc />
+    public IScissorHandsApplicationBuilder AddLayouts<TMainLayout, TIndexView, TPostView, TPageView, TNotFoundView>()
+        where TMainLayout : MainLayoutBase
+        where TIndexView : IndexViewBase
+        where TPostView : PostViewBase
+        where TPageView : PageViewBase
+        where TNotFoundView : NotFoundViewBase
+    {
+        return AddLayouts(typeof(TMainLayout), typeof(TIndexView), typeof(TPostView), typeof(TPageView), typeof(TNotFoundView));
+    }
+
+    /// <inheritdoc />
+    public IScissorHandsApplicationBuilder AddLayouts(Type mainLayout, Type indexView, Type postView, Type pageView, Type notFoundView)
+    {
+        ArgumentNullException.ThrowIfNull(mainLayout);
+        ArgumentNullException.ThrowIfNull(indexView);
+        ArgumentNullException.ThrowIfNull(postView);
+        ArgumentNullException.ThrowIfNull(pageView);
+        ArgumentNullException.ThrowIfNull(notFoundView);
+
+        EnsureAssignableTo<MainLayoutBase>(mainLayout, nameof(mainLayout));
+        EnsureAssignableTo<IndexViewBase>(indexView, nameof(indexView));
+        EnsureAssignableTo<PostViewBase>(postView, nameof(postView));
+        EnsureAssignableTo<PageViewBase>(pageView, nameof(pageView));
+        EnsureAssignableTo<NotFoundViewBase>(notFoundView, nameof(notFoundView));
+
+        _mainLayout = mainLayout;
+        _indexView = indexView;
+        _postView = postView;
+        _pageView = pageView;
+        _notFoundView = notFoundView;
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IScissorHandsApplication Build()
+    {
+        if (_mainLayout is null || _indexView is null || _postView is null || _pageView is null || _notFoundView is null)
+        {
+            throw new InvalidOperationException("Layouts are not configured. Call AddLayouts(...) before Build().");
+        }
+
+        var builder = WebApplication.CreateBuilder(_args);
+
+        var config = builder.Configuration;
+        builder.Services
+               .AddConfigurations(config)
+               .AddServices(config)
+               .AddRazorComponents();
+
+        var app = builder.Build();
+
+        return new ScissorHandsApplication(app, _args, _mainLayout, _indexView, _postView, _pageView, _notFoundView);
+    }
+
+    private static void EnsureAssignableTo<TBase>(Type type, string paramName)
+    {
+        if (typeof(TBase).IsAssignableFrom(type) == false)
+        {
+            throw new ArgumentException($"Type '{type.FullName}' must derive from '{typeof(TBase).FullName}'.", paramName);
+        }
+    }
+}

--- a/src/ScissorHands.Web/themes/default/IndexView.razor
+++ b/src/ScissorHands.Web/themes/default/IndexView.razor
@@ -3,11 +3,13 @@
 
 <section class="home">
     <article>
-        @if (Documents?.Any() == false)
+        @if (Documents?.Any() != true)
         {
             <p>Welcome aboard ScissorHands.NET!</p>
         }
-        @foreach (var post in Documents!)
+        else
+        {
+            @foreach (var post in Documents!)
         {
             <article>
                 <div>
@@ -20,6 +22,7 @@
                     </div>
                 }
             </article>
+            }
         }
     </article>
 </section>

--- a/src/ScissorHands.Web/themes/default/IndexView.razor
+++ b/src/ScissorHands.Web/themes/default/IndexView.razor
@@ -3,11 +3,11 @@
 
 <section class="home">
     <article>
-        @if (Documents.Any() == false)
+        @if (Documents?.Any() == false)
         {
             <p>Welcome aboard ScissorHands.NET!</p>
         }
-        @foreach (var post in Documents)
+        @foreach (var post in Documents!)
         {
             <article>
                 <div>

--- a/src/ScissorHands.Web/themes/default/MainLayout.razor
+++ b/src/ScissorHands.Web/themes/default/MainLayout.razor
@@ -1,5 +1,7 @@
 @inherits ScissorHands.Theme.MainLayoutBase
 
+<CascadingMainLayoutBase Documents="@Documents" Document="@Document" Plugins="@Plugins" Theme="@Theme" Site="@Site">
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -32,3 +34,5 @@
     }
 </body>
 </html>
+
+</CascadingMainLayoutBase>

--- a/src/ScissorHands.Web/themes/default/NotFoundView.razor
+++ b/src/ScissorHands.Web/themes/default/NotFoundView.razor
@@ -2,7 +2,7 @@
 @layout MainLayout
 
 <section class="not-found">
-    @if (string.IsNullOrWhiteSpace(Document.Html))
+    @if (string.IsNullOrWhiteSpace(Document?.Html) == true)
     {
         <article>
             <h1>404 - Not Found</h1>

--- a/src/ScissorHands.Web/themes/default/PageView.razor
+++ b/src/ScissorHands.Web/themes/default/PageView.razor
@@ -3,6 +3,6 @@
 
 <section class="page">
     <article>
-        @((MarkupString)Document.Html)
+        @((MarkupString)Document?.Html!)
     </article>
 </section>

--- a/src/ScissorHands.Web/themes/default/PostView.razor
+++ b/src/ScissorHands.Web/themes/default/PostView.razor
@@ -3,6 +3,6 @@
 
 <section class="post">
     <article>
-        @((MarkupString)Document.Html)
+        @((MarkupString)Document?.Html!)
     </article>
 </section>

--- a/src/ScissorHands.Web/themes/default/_Imports.razor
+++ b/src/ScissorHands.Web/themes/default/_Imports.razor
@@ -1,3 +1,5 @@
+@using ScissorHands.Theme
+
 @using Theme = ScissorHands.Core.Manifests.ThemeManifest
 
 @namespace ScissorHands.Web

--- a/test/ScissorHands.Theme.Tests/IndexViewBaseTests.cs
+++ b/test/ScissorHands.Theme.Tests/IndexViewBaseTests.cs
@@ -1,3 +1,6 @@
+using ScissorHands.Core.Manifests;
+using ScissorHands.Core.Models;
+
 namespace ScissorHands.Theme.Tests;
 
 public class IndexViewBaseTests
@@ -12,6 +15,34 @@ public class IndexViewBaseTests
 
         // Assert
         view.Documents.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Given_IndexViewBase_When_RenderedWithCascadingValues_Then_It_Should_BindCascadingParameters()
+    {
+        // Arrange
+        using var context = new BunitContext();
+
+        var documents = new List<ContentDocument> { new() };
+        var plugins = new List<PluginManifest> { new() };
+        var theme = new ThemeManifest { Name = "test", Slug = "test" };
+        var site = new SiteManifest();
+
+        // Act
+        var cut = context.Renderer.Render<CascadingMainLayoutBase>(p => p
+            .Add(x => x.Documents, documents)
+            .Add(x => x.Plugins, plugins)
+            .Add(x => x.Theme, theme)
+            .Add(x => x.Site, site)
+            .AddChildContent<TestIndexView>());
+
+        var view = cut.FindComponent<TestIndexView>().Instance;
+
+        // Assert
+        view.Documents.ShouldBeSameAs(documents);
+        view.Plugins.ShouldBeSameAs(plugins);
+        view.Theme.ShouldBeSameAs(theme);
+        view.Site.ShouldBeSameAs(site);
     }
 }
 

--- a/test/ScissorHands.Theme.Tests/IndexViewBaseTests.cs
+++ b/test/ScissorHands.Theme.Tests/IndexViewBaseTests.cs
@@ -3,7 +3,7 @@ namespace ScissorHands.Theme.Tests;
 public class IndexViewBaseTests
 {
     [Fact]
-    public void Given_IndexViewBase_When_Constructed_Then_It_Should_HaveNonNullDocuments()
+    public void Given_IndexViewBase_When_Constructed_Then_It_Should_HaveNullDocuments()
     {
         // Arrange
 
@@ -11,8 +11,7 @@ public class IndexViewBaseTests
         var view = new TestIndexView();
 
         // Assert
-        view.Documents.ShouldNotBeNull();
-        view.Documents.ShouldBeEmpty();
+        view.Documents.ShouldBeNull();
     }
 }
 

--- a/test/ScissorHands.Theme.Tests/NotFoundViewBaseTests.cs
+++ b/test/ScissorHands.Theme.Tests/NotFoundViewBaseTests.cs
@@ -1,3 +1,6 @@
+using ScissorHands.Core.Manifests;
+using ScissorHands.Core.Models;
+
 namespace ScissorHands.Theme.Tests;
 
 public class NotFoundViewBaseTests
@@ -12,6 +15,37 @@ public class NotFoundViewBaseTests
 
         // Assert
         view.Document.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Given_NotFoundViewBase_When_RenderedWithCascadingValues_Then_It_Should_BindCascadingParameters()
+    {
+        // Arrange
+        using var context = new BunitContext();
+
+        var document = new ContentDocument
+        {
+            Metadata = new ContentMetadata { Title = "Not Found", Slug = "404.html" }
+        };
+        var plugins = new List<PluginManifest> { new() };
+        var theme = new ThemeManifest { Name = "test", Slug = "test" };
+        var site = new SiteManifest();
+
+        // Act
+        var cut = context.Renderer.Render<CascadingMainLayoutBase>(p => p
+            .Add(x => x.Document, document)
+            .Add(x => x.Plugins, plugins)
+            .Add(x => x.Theme, theme)
+            .Add(x => x.Site, site)
+            .AddChildContent<TestNotFoundView>());
+
+        var view = cut.FindComponent<TestNotFoundView>().Instance;
+
+        // Assert
+        view.Document.ShouldBeSameAs(document);
+        view.Plugins.ShouldBeSameAs(plugins);
+        view.Theme.ShouldBeSameAs(theme);
+        view.Site.ShouldBeSameAs(site);
     }
 }
 

--- a/test/ScissorHands.Theme.Tests/NotFoundViewBaseTests.cs
+++ b/test/ScissorHands.Theme.Tests/NotFoundViewBaseTests.cs
@@ -3,7 +3,7 @@ namespace ScissorHands.Theme.Tests;
 public class NotFoundViewBaseTests
 {
     [Fact]
-    public void Given_NotFoundViewBase_When_Constructed_Then_It_Should_HaveNonNullDocument()
+    public void Given_NotFoundViewBase_When_Constructed_Then_It_Should_HaveNullDocument()
     {
         // Arrange
 
@@ -11,7 +11,7 @@ public class NotFoundViewBaseTests
         var view = new TestNotFoundView();
 
         // Assert
-        view.Document.ShouldNotBeNull();
+        view.Document.ShouldBeNull();
     }
 }
 

--- a/test/ScissorHands.Theme.Tests/PageViewBaseTests.cs
+++ b/test/ScissorHands.Theme.Tests/PageViewBaseTests.cs
@@ -1,3 +1,6 @@
+using ScissorHands.Core.Manifests;
+using ScissorHands.Core.Models;
+
 namespace ScissorHands.Theme.Tests;
 
 public class PageViewBaseTests
@@ -12,6 +15,37 @@ public class PageViewBaseTests
 
         // Assert
         view.Document.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Given_PageViewBase_When_RenderedWithCascadingValues_Then_It_Should_BindCascadingParameters()
+    {
+        // Arrange
+        using var context = new BunitContext();
+
+        var document = new ContentDocument
+        {
+            Metadata = new ContentMetadata { Title = "Hello", Slug = "hello" }
+        };
+        var plugins = new List<PluginManifest> { new() };
+        var theme = new ThemeManifest { Name = "test", Slug = "test" };
+        var site = new SiteManifest();
+
+        // Act
+        var cut = context.Renderer.Render<CascadingMainLayoutBase>(p => p
+            .Add(x => x.Document, document)
+            .Add(x => x.Plugins, plugins)
+            .Add(x => x.Theme, theme)
+            .Add(x => x.Site, site)
+            .AddChildContent<TestPageView>());
+
+        var view = cut.FindComponent<TestPageView>().Instance;
+
+        // Assert
+        view.Document.ShouldBeSameAs(document);
+        view.Plugins.ShouldBeSameAs(plugins);
+        view.Theme.ShouldBeSameAs(theme);
+        view.Site.ShouldBeSameAs(site);
     }
 }
 

--- a/test/ScissorHands.Theme.Tests/PageViewBaseTests.cs
+++ b/test/ScissorHands.Theme.Tests/PageViewBaseTests.cs
@@ -3,7 +3,7 @@ namespace ScissorHands.Theme.Tests;
 public class PageViewBaseTests
 {
     [Fact]
-    public void Given_PageViewBase_When_Constructed_Then_It_Should_HaveNonNullDocument()
+    public void Given_PageViewBase_When_Constructed_Then_It_Should_HaveNullDocument()
     {
         // Arrange
 
@@ -11,7 +11,7 @@ public class PageViewBaseTests
         var view = new TestPageView();
 
         // Assert
-        view.Document.ShouldNotBeNull();
+        view.Document.ShouldBeNull();
     }
 }
 

--- a/test/ScissorHands.Theme.Tests/PostViewBaseTests.cs
+++ b/test/ScissorHands.Theme.Tests/PostViewBaseTests.cs
@@ -3,7 +3,7 @@ namespace ScissorHands.Theme.Tests;
 public class PostViewBaseTests
 {
     [Fact]
-    public void Given_PostViewBase_When_Constructed_Then_It_Should_HaveNonNullDocument()
+    public void Given_PostViewBase_When_Constructed_Then_It_Should_HaveNullDocument()
     {
         // Arrange
 
@@ -11,7 +11,7 @@ public class PostViewBaseTests
         var view = new TestPostView();
 
         // Assert
-        view.Document.ShouldNotBeNull();
+        view.Document.ShouldBeNull();
     }
 }
 

--- a/test/ScissorHands.Theme.Tests/PostViewBaseTests.cs
+++ b/test/ScissorHands.Theme.Tests/PostViewBaseTests.cs
@@ -1,3 +1,6 @@
+using ScissorHands.Core.Manifests;
+using ScissorHands.Core.Models;
+
 namespace ScissorHands.Theme.Tests;
 
 public class PostViewBaseTests
@@ -12,6 +15,37 @@ public class PostViewBaseTests
 
         // Assert
         view.Document.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Given_PostViewBase_When_RenderedWithCascadingValues_Then_It_Should_BindCascadingParameters()
+    {
+        // Arrange
+        using var context = new BunitContext();
+
+        var document = new ContentDocument
+        {
+            Metadata = new ContentMetadata { Title = "Hello", Slug = "hello" }
+        };
+        var plugins = new List<PluginManifest> { new() };
+        var theme = new ThemeManifest { Name = "test", Slug = "test" };
+        var site = new SiteManifest();
+
+        // Act
+        var cut = context.Renderer.Render<CascadingMainLayoutBase>(p => p
+            .Add(x => x.Document, document)
+            .Add(x => x.Plugins, plugins)
+            .Add(x => x.Theme, theme)
+            .Add(x => x.Site, site)
+            .AddChildContent<TestPostView>());
+
+        var view = cut.FindComponent<TestPostView>().Instance;
+
+        // Assert
+        view.Document.ShouldBeSameAs(document);
+        view.Plugins.ShouldBeSameAs(plugins);
+        view.Theme.ShouldBeSameAs(theme);
+        view.Site.ShouldBeSameAs(site);
     }
 }
 

--- a/test/ScissorHands.Web.Tests/Renderers/ComponentRendererCascadingParametersTests.cs
+++ b/test/ScissorHands.Web.Tests/Renderers/ComponentRendererCascadingParametersTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using ScissorHands.Core.Manifests;
+using ScissorHands.Core.Models;
+using ScissorHands.Theme;
+using ScissorHands.Web.Renderers;
+
+namespace ScissorHands.Web.Tests.Renderers;
+
+public class ComponentRendererCascadingParametersTests
+{
+    [Fact]
+    public async Task Given_ComponentRenderer_When_RenderingWithLayout_Then_It_Should_PassCascadingValuesViaLayout_NotAsComponentAttributes()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        using var provider = services.BuildServiceProvider();
+
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+        var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
+
+        var renderer = new ComponentRenderer(scopeFactory, loggerFactory);
+
+        var document = new ContentDocument
+        {
+            Metadata = new ContentMetadata { Title = "Hello", Slug = "hello" }
+        };
+        var plugins = new List<PluginManifest> { new() };
+        var theme = new ThemeManifest { Name = "test", Slug = "test" };
+        var site = new SiteManifest();
+
+        var parameters = new Dictionary<string, object?>
+        {
+            ["Document"] = document,
+            ["Plugins"] = plugins,
+            ["Theme"] = theme,
+            ["Site"] = site,
+            ["Extra"] = "extra"
+        };
+
+        // Act
+        var html = await renderer.RenderAsync<TestCascadingPageView>(typeof(TestCascadingLayout), parameters);
+
+        // Assert
+        html.ShouldContain("extra");
+        html.ShouldContain("Hello");
+    }
+
+    private sealed class TestCascadingLayout : LayoutComponentBase
+    {
+        [Parameter]
+        public IEnumerable<ContentDocument>? Documents { get; set; }
+
+        [Parameter]
+        public ContentDocument? Document { get; set; }
+
+        [Parameter]
+        public IEnumerable<PluginManifest>? Plugins { get; set; }
+
+        [Parameter]
+        public ThemeManifest? Theme { get; set; }
+
+        [Parameter]
+        public SiteManifest? Site { get; set; }
+
+        [Parameter]
+        public string? Extra { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<CascadingMainLayoutBase>(0);
+            builder.AddAttribute(1, nameof(CascadingMainLayoutBase.Documents), Documents);
+            builder.AddAttribute(2, nameof(CascadingMainLayoutBase.Document), Document);
+            builder.AddAttribute(3, nameof(CascadingMainLayoutBase.Plugins), Plugins);
+            builder.AddAttribute(4, nameof(CascadingMainLayoutBase.Theme), Theme);
+            builder.AddAttribute(5, nameof(CascadingMainLayoutBase.Site), Site);
+            builder.AddAttribute(6, nameof(CascadingMainLayoutBase.ChildContent), (RenderFragment)(b => b.AddContent(0, Body)));
+            builder.CloseComponent();
+        }
+    }
+
+    private sealed class TestCascadingPageView : PageViewBase
+    {
+        [Parameter]
+        public string? Extra { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddContent(1, $"{Extra}|{Document?.Metadata.Title}");
+            builder.CloseElement();
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Switch theme view base types (`IndexViewBase`, `PageViewBase`, `PostViewBase`, `NotFoundViewBase`) from direct `[Parameter]` inputs to `[CascadingParameter]` so themes can receive context consistently via the layout.
* Update the default theme layout to provide these values via `CascadingMainLayoutBase`.
* Adjust rendering/generation pipeline to align with the cascading approach and add/extend unit tests.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
[ ] N/A
```

## How to Test
*  Get the code

```
git clone https://github.com/getscissorhands/Scissorhands.NET
cd Scissorhands.NET
git checkout feat/cacading-parameters
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
dotnet test test/ScissorHands.Theme.Tests/ScissorHands.Theme.Tests.csproj -c Release
dotnet test test/ScissorHands.Web.Tests/ScissorHands.Web.Tests.csproj -c Release
```

## What to Check
Verify that the following are valid
* Theme views can access `Document(s)`, `Plugins`, `Theme`, and `Site` via cascading parameters when rendered under the main layout.
* Default theme renders pages/posts/404 without requiring these values as direct component attributes.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
* Theme authors may need to wrap their layout with `CascadingMainLayoutBase` (or otherwise provide equivalent cascading values) to populate the view base properties.