### PR TITLE
feat(theme): add shared theme URL helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A Blazor-based static site generator
 
     var app = new ScissorHandsApplicationBuilder(args)
                   .Build();
+
     await app.RunAsync();
     ```
 
@@ -55,13 +56,13 @@ A Blazor-based static site generator
 
 > **NOTE**: For more details to run a ScissorHands.NET app, visit the [Quickstart](https://getscissorhands.app/docs/quickstart/) page.
 
-## Sample Application
+## Engine Preview
 
-The [`samples/ScissorHands.Sample`](./samples/ScissorHands.Sample) project references the engine projects directly and uses the built-in default theme. It can be used to preview local engine changes without publishing packages:
+The [`samples/ScissorHands.Sample`](./samples/ScissorHands.Sample) project references the engine projects directly and uses the built-in default theme. Use this preview app to check how the engine works, without building a new app.
 
 ```bash
 cd samples/ScissorHands.Sample
-dotnet run
+dotnet run -- --preview
 ```
 
 ## vNext Compatibility

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A Blazor-based static site generator
 
+[![ScissorHands.Core NuGet](https://img.shields.io/nuget/vpre/ScissorHands.Core.svg?label=ScissorHands.Core)](https://www.nuget.org/packages/ScissorHands.Core)
+[![ScissorHands.Plugin NuGet](https://img.shields.io/nuget/vpre/ScissorHands.Plugin.svg?label=ScissorHands.Plugin)](https://www.nuget.org/packages/ScissorHands.Plugin)
+[![ScissorHands.Theme NuGet](https://img.shields.io/nuget/vpre/ScissorHands.Theme.svg?label=ScissorHands.Theme)](https://www.nuget.org/packages/ScissorHands.Theme)
+[![ScissorHands.Web NuGet](https://img.shields.io/nuget/vpre/ScissorHands.Web.svg?label=ScissorHands.Web)](https://www.nuget.org/packages/ScissorHands.Web)
+
 ## Prerequisites
 
 - [.NET 10+ SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
@@ -15,15 +20,13 @@ A Blazor-based static site generator
     dotnet new web -n MyScissorHandsApp
     ```
 
-1. Add the NuGet package.
+1. Add the NuGet package. Make sure to add the `--prerelease` option because it's currently in public preview.
 
     ```bash
     dotnet add ./MyScissorHandsApp package ScissorHands.Web --prerelease
     ```
 
-   > Currently, ScissorHands is public preview. Therefore, add the `--prerelease` option.
-
-1. Open `Program.cs` and add the following codes.
+1. Open `Program.cs` and replace the existing codes with the following:
 
     ```csharp
     using ScissorHands.Web;
@@ -33,8 +36,6 @@ A Blazor-based static site generator
 
     await app.RunAsync();
     ```
-
-   The theme is discovered automatically from the `Site:Theme` slug in `appsettings.json`. Theme Razor components should share a namespace whose normalized suffix matches the theme slug, such as `ScissorHands.Theme.MinimalBlog` for `minimal-blog`.
 
 1. Build the app.
 
@@ -54,7 +55,10 @@ A Blazor-based static site generator
     dotnet run -- --build
     ```
 
-> **NOTE**: For more details to run a ScissorHands.NET app, visit the [Quickstart](https://getscissorhands.app/docs/quickstart/) page.
+1. Add a GitHub Actions workflow to publish the app to [GitHub Pages](https://docs.github.com/pages/quickstart) or any static page hosting services.
+
+> [!NOTE]
+> For more details to run a ScissorHands.NET app, visit the [Quickstart](https://getscissorhands.app/docs/quickstart) page.
 
 ## Engine Preview
 

--- a/samples/ScissorHands.Sample/Program.cs
+++ b/samples/ScissorHands.Sample/Program.cs
@@ -1,4 +1,5 @@
 using ScissorHands.Web;
 
 var app = new ScissorHandsApplicationBuilder(args).Build();
+
 await app.RunAsync();

--- a/src/ScissorHands.Theme/MainLayoutBase.cs
+++ b/src/ScissorHands.Theme/MainLayoutBase.cs
@@ -101,6 +101,22 @@ public abstract class MainLayoutBase : LayoutComponentBase
     }
 
     /// <summary>
+    /// Gets a base-relative URL for a path within the current theme.
+    /// </summary>
+    /// <param name="path">The theme-relative path, optionally prefixed with slashes.</param>
+    /// <returns>The URL relative to the site's base URL.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="Theme"/> has not been supplied.</exception>
+    protected string GetThemeUrl(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        var theme = Theme ?? throw new InvalidOperationException("A theme must be supplied before getting a theme URL.");
+
+        return $"{ThemeManifest.THEME_DIRECTORY}/{theme.Slug.Trim('/')}/{path.TrimStart('/')}";
+    }
+
+    /// <summary>
     /// Calculates the page title based on the site and document title.
     /// </summary>
     /// <returns>Returns the page title calculated.</returns>

--- a/src/ScissorHands.Theme/README.md
+++ b/src/ScissorHands.Theme/README.md
@@ -127,9 +127,13 @@ Store theme assets below `themes/{slug}/assets/` and list them in `theme.json`.
 Internal links and asset URLs should be base-relative, without a leading `/`, so sites published below a path such as `/docs/` continue to work:
 
 ```razor
-<link rel="stylesheet" href="themes/minimal-blog/assets/theme.css" />
+<link rel="stylesheet" href="@GetThemeUrl("/assets/theme.css")" />
 <a href="tags">Tags</a>
 ```
+
+Layouts derived from `MainLayoutBase` can use the protected `GetThemeUrl(string path)` helper for theme assets. With a theme slug of `minimal-blog`, the example returns `themes/minimal-blog/assets/theme.css`. The helper trims leading and trailing `/` characters from the slug and leading `/` characters from the path.
+
+The returned URL is relative to the `<base href="@Site!.BaseUrl" />` in the layout; it does not prepend `Site.BaseUrl`. Supply the `Theme` parameter before calling the helper. A missing theme throws `InvalidOperationException`, and a null path throws `ArgumentNullException`.
 
 ## Start from the template
 

--- a/src/ScissorHands.Web/themes/default/MainLayout.razor
+++ b/src/ScissorHands.Web/themes/default/MainLayout.razor
@@ -10,7 +10,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="generator" content="@Site.Generator" />
         <meta name="theme-color" content="#fffcf5" />
-        <link rel="icon" type="image/x-icon" href="@ThemeUrl("favicon.ico")" />
+        <link rel="icon" type="image/x-icon" href="@GetThemeUrl("favicon.ico")" />
 
         <title>@PageTitle</title>
         <meta name="title" content="@PageTitle" />
@@ -24,7 +24,7 @@
         </script>
         @foreach (var css in Theme!.Stylesheets)
         {
-            <link rel="stylesheet" href="@ThemeUrl(css)" />
+            <link rel="stylesheet" href="@GetThemeUrl(css)" />
         }
     </head>
     <body>
@@ -60,13 +60,8 @@
 
         @foreach (var script in Theme.Scripts)
         {
-            <script src="@ThemeUrl(script)"></script>
+            <script src="@GetThemeUrl(script)"></script>
         }
     </body>
     </html>
 </CascadingMainLayoutBase>
-
-@code {
-    private string ThemeUrl(string path)
-        => $"themes/{Theme!.Slug.TrimEnd('/')}/{path.TrimStart('/')}";
-}

--- a/test/ScissorHands.Theme.Tests/MainLayoutBaseTests.cs
+++ b/test/ScissorHands.Theme.Tests/MainLayoutBaseTests.cs
@@ -9,6 +9,83 @@ namespace ScissorHands.Theme.Tests;
 
 public class MainLayoutBaseTests
 {
+    [Theory]
+    [InlineData("minimal", "assets/theme.css", "themes/minimal/assets/theme.css")]
+    [InlineData("minimal", "/assets/theme.css", "themes/minimal/assets/theme.css")]
+    [InlineData("/minimal/", "assets/theme.css", "themes/minimal/assets/theme.css")]
+    [InlineData("///minimal///", "///assets/theme.css", "themes/minimal/assets/theme.css")]
+    [InlineData("minimal", "", "themes/minimal/")]
+    [InlineData("minimal", "/", "themes/minimal/")]
+    [InlineData("minimal", "/assets/theme.css?v=1#theme", "themes/minimal/assets/theme.css?v=1#theme")]
+    public void Given_ThemeAndPath_When_GetThemeUrl_Invoked_Then_It_Should_ReturnBaseRelativeUrl(string slug, string path, string expected)
+    {
+        // Arrange
+        using var context = new BunitContext();
+        context.Services.AddSingleton(Substitute.For<IThemeService>());
+
+        var cut = context.Renderer.Render<TestMainLayout>(parameters => parameters
+            .Add(p => p.Theme, new ThemeManifest { Slug = slug }));
+
+        // Act
+        var result = cut.Instance.InvokeGetThemeUrl(path);
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("/", "https://example.com/themes/minimal/assets/theme.css")]
+    [InlineData("/docs/", "https://example.com/docs/themes/minimal/assets/theme.css")]
+    public void Given_SiteBaseUrl_When_GetThemeUrl_Invoked_Then_It_Should_ResolveUnderSiteBaseUrl(string baseUrl, string expected)
+    {
+        // Arrange
+        using var context = new BunitContext();
+        context.Services.AddSingleton(Substitute.For<IThemeService>());
+
+        var site = new SiteManifest { BaseUrl = baseUrl };
+        var cut = context.Renderer.Render<TestMainLayout>(parameters => parameters
+            .Add(p => p.Site, site)
+            .Add(p => p.Theme, new ThemeManifest { Slug = "minimal" }));
+
+        // Act
+        var result = cut.Instance.InvokeGetThemeUrl("/assets/theme.css");
+        var resolved = new Uri(new Uri($"https://example.com{site.BaseUrl}"), result);
+
+        // Assert
+        result.ShouldBe("themes/minimal/assets/theme.css");
+        resolved.AbsoluteUri.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Given_NullPath_When_GetThemeUrl_Invoked_Then_It_Should_ThrowArgumentNullException()
+    {
+        // Arrange
+        using var context = new BunitContext();
+        context.Services.AddSingleton(Substitute.For<IThemeService>());
+
+        var cut = context.Renderer.Render<TestMainLayout>(parameters => parameters
+            .Add(p => p.Theme, new ThemeManifest { Slug = "minimal" }));
+
+        // Act
+        var exception = Should.Throw<ArgumentNullException>(() => cut.Instance.InvokeGetThemeUrl(null!));
+
+        // Assert
+        exception.ParamName.ShouldBe("path");
+    }
+
+    [Fact]
+    public void Given_MissingTheme_When_GetThemeUrl_Invoked_Then_It_Should_ThrowInvalidOperationException()
+    {
+        // Arrange
+        var component = new TestMainLayout();
+
+        // Act
+        var exception = Should.Throw<InvalidOperationException>(() => component.InvokeGetThemeUrl("assets/theme.css"));
+
+        // Assert
+        exception.Message.ShouldBe("A theme must be supplied before getting a theme URL.");
+    }
+
     [Fact]
     public void Given_SiteAndTheme_When_Rendered_Then_It_Should_SetPageMetadata_And_UseProvidedTheme()
     {
@@ -171,6 +248,8 @@ internal class TestMainLayout : MainLayoutBase
     public string? ExposedPageTitle => PageTitle;
     public string? ExposedPageDescription => PageDescription;
     public string? ExposedPageLocale => PageLocale;
+
+    public string InvokeGetThemeUrl(string path) => GetThemeUrl(path);
 
     public string InvokeCalculatePageTitle() => CalculatePageTitle();
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Theme authors currently have to construct theme asset URLs themselves. Add a shared helper for derived layouts and improve package discovery and getting-started guidance.

- Expose protected `GetThemeUrl(string path)` on `MainLayoutBase`. It trims surrounding slashes from the theme slug and leading slashes from the path, returning a base-relative URL compatible with subpath hosting. Null paths and missing themes throw explicit exceptions.
- Reuse the helper for the built-in theme's favicon, stylesheets, and scripts, and document usage in the Theme package README.
- Add labeled NuGet version badges for Core, Plugin, Theme, and Web, including prerelease versions. Simplify setup instructions, remove theme-authoring details from Getting Started, and mention static-site publishing.
- Present the existing sample as an engine preview with an explicit preview command and align startup snippet spacing.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
[ ] N/A
```

Updated the root and Theme package READMEs. No new sample was added.

## How to Test
* Get the code

```
git clone https://github.com/getscissorhands/Scissorhands.NET.git
cd Scissorhands.NET
git checkout justinyoo-theme-url-helper
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```powershell
dotnet restore .\ScissorHands.slnx
dotnet test --project .\test\ScissorHands.Theme.Tests\ScissorHands.Theme.Tests.csproj -c Release --no-restore
dotnet build .\ScissorHands.slnx -c Release --no-restore
dotnet test --solution .\ScissorHands.slnx -c Release --no-build --verbosity normal
Push-Location .\samples\ScissorHands.Sample
dotnet run -c Release --no-build --no-launch-profile -- --build
Pop-Location
```

## What to Check
Verify that the following are valid
* Derived layouts can call `GetThemeUrl`; slash trimming, empty paths, and query strings/fragments preserve the expected output.
* URLs remain base-relative and resolve correctly under both `/` and `/docs/` without prepending `Site.BaseUrl` in the helper.
* Null paths and missing themes throw the documented exceptions.
* Generated favicon, stylesheet, and script URLs point to existing theme assets.
* The four README badges identify and link to their respective NuGet packages, and the engine preview instructions use the existing sample.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
The helper implementation passed a Release build with no warnings or errors and all 212 tests, including 33 Theme tests. Sample generation succeeded; all eight generated pages contained three base-relative theme asset URLs with matching files. These checks preceded the subsequent README and whitespace-only sample updates; the .NET suite was not rerun for those nonfunctional changes.